### PR TITLE
Added Toaster component

### DIFF
--- a/app/app/App.js
+++ b/app/app/App.js
@@ -11,6 +11,7 @@ import Splashscreen from './components/Splashscreen';
 import ContextMenu from './components/ContextMenu';
 import KeyListener from './components/KeyListener';
 import { Database } from './components/Database';
+import { Toaster } from './components/Toaster';
 
 /* Relative Pages */
 import Movies from './pages/Movies';
@@ -33,25 +34,27 @@ class App extends Component {
     }
 
     render () {
-        const { remote, initiating } = this.props;
+        const { remote, initiating, toastRoot } = this.props;
 
         return (
             <RemoteContext.Provider value={remote}>
-                <Database>
-                    <ContextMenu />
-                    <KeyListener />
-                    <GoogleFontLoader fonts={fonts} />
+                <Toaster renderTo={toastRoot}>
+                    <Database>
+                        <ContextMenu />
+                        <KeyListener />
+                        <GoogleFontLoader fonts={fonts} />
 
-                    <Splashscreen delay={1500} ready={!initiating}>
-                        <Router>
-                            <Switch>
-                                <Route exact path="/" component={Movies} />
-                                <Route exact path="/movies/:id" component={Movie} />
-                                <Route exact path="/movies/:id/watch" component={Video} />
-                            </Switch>
-                        </Router>
-                    </Splashscreen>
-                </Database>
+                        <Splashscreen delay={1500} ready={!initiating}>
+                            <Router>
+                                <Switch>
+                                    <Route exact path="/" component={Movies} />
+                                    <Route exact path="/movies/:id" component={Movie} />
+                                    <Route exact path="/movies/:id/watch" component={Video} />
+                                </Switch>
+                            </Router>
+                        </Splashscreen>
+                    </Database>
+                </Toaster>
             </RemoteContext.Provider>
         );
     }

--- a/app/app/components/Splashscreen/index.js
+++ b/app/app/components/Splashscreen/index.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import { css } from 'aphrodite';
 
+import { withToaster } from '../Toaster';
+
 /* Relative */
 import defaultProps from './defaultProps';
 import propTypes from './propTypes';
@@ -25,6 +27,9 @@ class Splashscreen extends React.Component {
     componentDidMount () {
         // Save a timestamp of when the component mounted.
         this.mountedAt = this.getTimestamp();
+
+        const { toast } = this.props;
+        toast('Splashscreen!');
     }
 
     componentWillUnmount () {
@@ -91,4 +96,4 @@ class Splashscreen extends React.Component {
     }
 }
 
-export default Splashscreen;
+export default withToaster(Splashscreen);

--- a/app/app/components/Toaster/ToastContext.js
+++ b/app/app/components/Toaster/ToastContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const ToastContext = createContext();

--- a/app/app/components/Toaster/Toaster.js
+++ b/app/app/components/Toaster/Toaster.js
@@ -1,0 +1,140 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import uuid from 'uuid/v4';
+import { css } from 'aphrodite';
+
+import { ToastContext } from './ToastContext';
+import propTypes from './Toaster.propTypes';
+import styles from './Toaster.styles';
+
+export class Toaster extends React.Component {
+    static propTypes = propTypes;
+
+    /**
+     * State.
+     */
+    state = { toasts: {} };
+
+    /**
+     * Array of all timeouts.
+     */
+    timeouts = [];
+
+    /**
+     * Handles unmount.
+     */
+    componentWillUnmount () {
+        // Clear any timeouts and remove them from the array.
+        this.timeouts.filter((timeout) => {
+            clearTimeout(timeout);
+            return false;
+        });
+    }
+
+    /**
+     * Adds a toast to state.
+     *
+     * @param {string} id
+     * @param {string} text
+     */
+    addToast = (id, text) => this.setState(prev => ({
+        toasts: {
+            ...prev.toasts,
+            [id]: {
+                text,
+                disappearing: false,
+            },
+        },
+    }));
+
+    /**
+     * Hides the specified toast.
+     *
+     * @param {string} id
+     */
+    hideToast = id => this.setState(prev => ({
+        toasts: {
+            ...prev.toasts,
+            [id]: {
+                ...prev.toasts[id],
+                disappearing: true,
+            },
+        },
+    }));
+
+    /**
+     * Deletes the specified toast.
+     *
+     * @param {string} id
+     */
+    deleteToast = id => this.setState(prev => ({
+        toasts: Object.entries(prev.toasts)
+            .filter(([key]) => key !== id)
+            .reduce((obj, [key, val]) => ({
+                ...obj,
+                [key]: val,
+            }), {}),
+    }));
+
+    /**
+     * The toast function that is exposed via
+     * the withToaster HOC.
+     */
+    toast = (text, duration = 2000) => {
+        const id = uuid();
+
+        this.addToast(id, text);
+
+        const slideInDuration = 500;
+        const fadeOutDuration = 200;
+
+        const timeout = setTimeout(() => {
+            this.hideToast(id);
+
+            const timeout2 = setTimeout(() => {
+                this.deleteToast(id);
+            }, fadeOutDuration);
+
+            this.timeouts.push(timeout2);
+        }, duration - fadeOutDuration + slideInDuration);
+
+        this.timeouts.push(timeout);
+    };
+
+    /**
+     * Renders the toasts.
+     */
+    renderToasts = () => {
+        const { toasts } = this.state;
+
+        return (
+            <div className={css(styles.toaster)}>
+                {Object.entries(toasts).map(([key, { text, disappearing }]) => (
+                    <div
+                        className={css(styles.toast, disappearing && styles.toast_disappearing)}
+                        key={key}
+                    >
+                        <p>{text}</p>
+                    </div>
+                ))}
+            </div>
+        );
+    };
+
+    /**
+     * Renders the component.
+     */
+    render () {
+        const { children, renderTo } = this.props;
+
+        return (
+            <ToastContext.Provider value={this.toast}>
+                {children}
+
+                {renderTo
+                    ? createPortal(this.renderToasts(), renderTo)
+                    : this.renderToasts()}
+            </ToastContext.Provider>
+        );
+    }
+}

--- a/app/app/components/Toaster/Toaster.js
+++ b/app/app/components/Toaster/Toaster.js
@@ -24,11 +24,7 @@ export class Toaster extends React.Component {
      * Handles unmount.
      */
     componentWillUnmount () {
-        // Clear any timeouts and remove them from the array.
-        this.timeouts.filter((timeout) => {
-            clearTimeout(timeout);
-            return false;
-        });
+        this.timeouts.forEach(clearTimeout);
     }
 
     /**

--- a/app/app/components/Toaster/Toaster.propTypes.js
+++ b/app/app/components/Toaster/Toaster.propTypes.js
@@ -1,0 +1,6 @@
+import PropTypes from 'prop-types';
+
+export default {
+    children: PropTypes.node,
+    renderTo: PropTypes.instanceOf(HTMLElement),
+};

--- a/app/app/components/Toaster/Toaster.styles.js
+++ b/app/app/components/Toaster/Toaster.styles.js
@@ -1,0 +1,53 @@
+import { StyleSheet } from 'aphrodite';
+import { rem, colors, px, second, translateY, fonts, shadows } from '../../../styles';
+
+const slideInKeyframes = {
+    from: {
+        opacity: 0,
+        transform: translateY(rem(1)),
+    },
+
+    to: {
+        opacity: 1,
+        transform: translateY(0),
+    },
+};
+
+const fadeOutKeyframes = {
+    from: { opacity: 1 },
+    to: { opacity: 0 },
+};
+
+export default StyleSheet.create({
+    toaster: {
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        display: 'flex',
+        flexDirection: 'column-reverse',
+        alignItems: 'center',
+    },
+
+    toast: {
+        padding: rem(1),
+        fontSize: rem(0.875),
+        fontFamily: fonts.primary,
+        background: colors.background.two,
+        color: colors.text.primary,
+        borderRadius: rem(0.25),
+        height: px(48),
+        marginBottom: rem(0.5),
+        width: 'auto',
+        minWidth: px(344),
+        animationName: slideInKeyframes,
+        animationDuration: second(0.5),
+        boxShadow: shadows.one,
+    },
+
+    toast_disappearing: {
+        animationName: fadeOutKeyframes,
+        animationDuration: second(0.2),
+        animationFillMode: 'forwards',
+    },
+});

--- a/app/app/components/Toaster/index.js
+++ b/app/app/components/Toaster/index.js
@@ -1,0 +1,2 @@
+export * from './Toaster';
+export * from './withToaster';

--- a/app/app/components/Toaster/withToaster.js
+++ b/app/app/components/Toaster/withToaster.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ToastContext } from './ToastContext';
+
+export const withToaster = (Comp) => {
+    const WrappedComp = props => (
+        <ToastContext.Consumer>
+            {toast => (
+                <Comp
+                    toast={toast}
+                    {...props}
+                />
+            )}
+        </ToastContext.Consumer>
+    );
+
+    WrappedComp.displayName = `withToaster(${Comp.displayName || Comp.name})`;
+
+    return WrappedComp;
+};

--- a/app/index.js
+++ b/app/index.js
@@ -8,8 +8,11 @@ import { remote } from 'electron';
 import App from './app';
 import store from './redux/bootstrap';
 
+const appRoot = document.getElementById('app');
+const toastRoot = document.getElementById('toasts');
+
 render((
     <Provider store={store}>
-        <App remote={remote} />
+        <App remote={remote} toastRoot={toastRoot} />
     </Provider>
-), document.getElementById('app'));
+), appRoot);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-virtualized": "^9.21.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
+    "uuid": "^3.3.2",
     "video.js": "^7.3.0",
     "webtorrent": "^0.102.4"
   }


### PR DESCRIPTION
Added in a toaster.

Has 2 components:

 - `<Toaster>` is top level, contains all logic. Renders in place or you can specify an element to render at using portals (which I have done).
 - `withToaster()` HOC which supplies a `toast` function as a prop. `toast` takes some text to show in the toast, and a duration, which defaults to 2000ms.
   - `toast(string text, int duration = 2000)`

I've added in a toast on the splashcreen component for demonstration purposes, obviously that can be removed!